### PR TITLE
fix: alertar a usuario de busqueda sin resultados

### DIFF
--- a/public/javascripts/populateCatalog.js
+++ b/public/javascripts/populateCatalog.js
@@ -2,9 +2,15 @@ import { productoApi } from "/static/classes/resources.js";
 import { populateCatalog } from "/static/javascripts/productsUI.js";
 
 import { renderPageButtons } from "/static/javascripts/pagination.js";
+import { displayResponseMessages } from "/static/javascripts/alertMessages.js";
 
 document.addEventListener("DOMContentLoaded", async function () {
-  await productoApi.buscar().then((data) => {
+  await productoApi.buscar().then(async (data) => {
+    if (data.search_result === undefined || data.search_result === null) {
+      productoApi.queryHandler.clearQuery();
+      data = await productoApi.buscar();
+    }
+
     populateCatalog(data);
     renderPageButtons(data);
   });
@@ -15,8 +21,14 @@ document.addEventListener("DOMContentLoaded", async function () {
   searchBox.addEventListener("keypress", async function (event) {
     if (event.key === "Enter") {
       await productoApi.buscar(true).then((data) => {
-        populateCatalog(data);
-        renderPageButtons(data);
+        if (data.search_result === undefined || data.search_result === null) {
+          productoApi.queryHandler.clearQuery();
+          data.status_code = 400;
+          displayResponseMessages({ data: data });
+        } else {
+          populateCatalog(data);
+          renderPageButtons(data);
+        }
       });
     }
   });
@@ -25,5 +37,6 @@ document.addEventListener("DOMContentLoaded", async function () {
 
   brandHomeButton.addEventListener("click", function () {
     productoApi.queryHandler.clearQuery();
+    window.location.href = "/";
   });
 });

--- a/views/partials/navBar.hbs
+++ b/views/partials/navBar.hbs
@@ -1,7 +1,7 @@
 <header>
     <nav class="navbar navbar-expand-lg bg-dark navbar-dark px-3 flex-column">
         <div class="container-fluid align-items-center justify-content-sm-center">
-            <a href="/" id="brand-home-button" class="navbar-brand">Catalogo</a>
+            <a href="#" id="brand-home-button" class="navbar-brand">Catalogo</a>
             {{>searchBox}}
             {{>createModal}}
         </div>


### PR DESCRIPTION
Previamente si una busqueda no obtenia resultados, el sitio se rompia al intentar renderizar el catalogo (vacio), ahora una vez se recibe la respuesta se valida si tiene contenido, si no, se advierte al usuario y se cancela el renderizado y persistencia de la busqueda.